### PR TITLE
Fix prototype pollution vulnerability in lodash-es

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5735,9 +5735,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "start": "next start",
     "lint": "next lint"
   },
+  "overrides": {
+    "lodash-es": "4.17.23"
+  },
   "dependencies": {
     "@codemirror/lang-markdown": "^6.2.5",
     "@google/generative-ai": "^0.16.0",


### PR DESCRIPTION
Updated `lodash-es` to version `4.17.23` using `overrides` in `package.json` to resolve a prototype pollution vulnerability. Verified that `package-lock.json` reflects the updated version for all dependencies. Reverted automatic changes to `tsconfig.json` generated by the build process.

---
*PR created automatically by Jules for task [13810150160038606746](https://jules.google.com/task/13810150160038606746) started by @aegisfleet*